### PR TITLE
position top fix

### DIFF
--- a/plugin/tasklist.vim
+++ b/plugin/tasklist.vim
@@ -134,7 +134,7 @@ endif
 function! s:OpenWindow(buffnr, lineno)
     " Open results window and place items there.
     if g:tlWindowPosition == 0
-      execute 'sp -TaskList_'.a:buffnr.'-'
+      execute 'topleft sp -TaskList_'.a:buffnr.'-'
     else
       execute 'botright sp -TaskList_'.a:buffnr.'-'
     endif


### PR DESCRIPTION
Explicitly put the window position at the top left if WindowPosition is 0 rather than deferring to the default. Mine was defaulting to bottom no matter what you put in WindowPosition.
